### PR TITLE
fix: Allow boolean and number values in reusable workflow inputs

### DIFF
--- a/lib/package/job.spec.ts
+++ b/lib/package/job.spec.ts
@@ -226,6 +226,17 @@ describe("Job", () => {
         { uses: "./workflow.yml" },
       ],
       [
+        new Job("with-inputs", {
+          uses: "./workflow.yml",
+          with: {
+            foo: "bar",
+            bar: 1,
+            baz: true,
+          },
+        }),
+        { uses: "./workflow.yml", with: { foo: "bar", bar: 1, baz: true } },
+      ],
+      [
         new Job("with-permissions", {
           uses: "./workflow.yml",
           permissions: {

--- a/lib/package/job.ts
+++ b/lib/package/job.ts
@@ -107,7 +107,7 @@ export type NormalJobConfig = JobConfigBase & {
 
 export type ReusableWorkflowCallJobConfig = JobConfigBase & {
   uses: string;
-  with?: Record<string, string>;
+  with?: Record<string, string | boolean | number>;
   secrets?: "inherit" | Record<string, string>;
 };
 


### PR DESCRIPTION
#116 